### PR TITLE
Remove new FB tracking params `__cft__[0]` and `__tn__`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Dev work on Web Extensions for Firefox, Chrome, and Brave.
 FBclid - Facebook Click Identifier.
 utm - Urchin Tracking Module. 
 
-For now, the full list of query params that get stripped out of URLs are "fbclid", "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", and "utm_brand".
+For now, the full list of query params that get stripped out of URLs are "fbclid", "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "utm_brand", "\_\_cft\_\_[0]" and "\_\_tn\_\_".
 
 ## Chrome Example
 Tutorial from Google on building Web Extensions: https://developer.chrome.com/extensions/getstarted

--- a/queryParamsRemover/queryParamsRemover.js
+++ b/queryParamsRemover/queryParamsRemover.js
@@ -7,7 +7,8 @@
 function stripBadQueryParams(request) {
   // console.log("Intercepting this request: ", JSON.stringify(request));
   const targetQueryParams = ["fbclid", "gclid", "utm_source", "utm_medium", "utm_term",
-                            "utm_campaign",  "utm_content", "utm_name"];
+                             "utm_campaign",  "utm_content", "utm_name",
+                             "__cft__[0]", "__tn__"];
 
   let requestedUrl = new URL(request.url);
   let match = false;


### PR DESCRIPTION
Question on StackOverflow:
https://stackoverflow.com/questions/64092454/what-is-the-purpose-of-the-new-cft-0-and-tn-parameters-in-facebook-po