### PR TITLE
ysclid for yandex

### DIFF
--- a/queryParamsRemover/queryParamsRemover.js
+++ b/queryParamsRemover/queryParamsRemover.js
@@ -6,7 +6,7 @@
 
 function stripBadQueryParams(request) {
   // console.log("Intercepting this request: ", JSON.stringify(request));
-  const targetQueryParams = ["fbclid", "gclid", "utm_source", "utm_medium", "utm_term",
+  const targetQueryParams = ["ysclid", "fbclid", "gclid", "utm_source", "utm_medium", "utm_term",
                             "utm_campaign",  "utm_content", "utm_name"];
 
   let requestedUrl = new URL(request.url);


### PR DESCRIPTION
Yandex began to use a special ysclid parameter - it adds it to the link by which the user uses the site from the Yandex search results. https://example.com/?ysclid=ksil7dwgjm. Using this parameter, Yandex.Metrica associates information about the user's visit with the search query. The new setting is already enabled for all sites in Yandex search results in browsers that restrict the use of cookies.